### PR TITLE
Header/metadata fix

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -18,11 +18,22 @@ export const pkgJson: Record<string, unknown> = {
 	version,
 	description,
 }
-
+/**
+ * Theme Json metadata headers
+ *
+ */
 export const themeJson = themei18n
 export const blockJson = blocki18n
 export const pkgJsonHeaders = packagei18n
+/**
+ * The Plugin metadata headers
+ * @link https://codex.wordpress.org/File_Header
+ */
 export const pluginHeaders = wpPlugini18n
+/**
+ * The Theme metadata headers
+ * @link https://developer.wordpress.org/plugins/plugin-basics/header-requirements/
+ */
 export const themeHeaders = wpThemei18n
 
 /**

--- a/src/extractors/headers.ts
+++ b/src/extractors/headers.ts
@@ -24,7 +24,7 @@ export function generateHeader(args: Args): Record<string, string> {
 	const headerData = {
 		...args.headers,
 		author: args.headers?.author || 'AUTHOR',
-		slug: args.headers?.slug || 'PLUGIN NAME',
+		slug: args.slug || 'PLUGIN NAME',
 		email: args.headers?.email || 'EMAIL',
 		license: args.headers?.license || 'gpl-2.0 or later',
 		version: args.headers?.version || 'VERSION',

--- a/src/extractors/headers.ts
+++ b/src/extractors/headers.ts
@@ -27,14 +27,17 @@ export function generateHeader(args: Args): Record<string, string> {
 		slug: args.slug || 'PLUGIN NAME',
 		email: args.headers?.email || 'EMAIL',
 		license: args.headers?.license || 'gpl-2.0 or later',
-		version: args.headers?.version || 'VERSION',
-		language: args.headers?.language || 'LANGUAGE',
-		domain: args.headers?.domain || args.headers?.slug || undefined,
+		version: args.headers?.version || '1.0.0',
+		language: args.headers?.language || 'en',
+		domain: args.headers?.textDomain || args.headers?.slug || undefined,
 		bugs: {
 			url:
-				args.headers?.bugs ||
+				args.headers?.bugsUrl ||
 				'https://wordpress.org/support/plugin/' + args.slug,
-			email: args.headers?.authoremail || 'AUTHOR EMAIL',
+			email:
+				args.headers?.bugsEmail ||
+				args.headers?.authoremail ||
+				'AUTHOR EMAIL',
 		},
 	} as const
 

--- a/src/extractors/headers.ts
+++ b/src/extractors/headers.ts
@@ -1,4 +1,4 @@
-import { Args } from '../types'
+import { Args, PotHeaders } from '../types'
 import { extractPhpPluginData } from './php'
 import { extractCssThemeData } from './css'
 import { gentranslation } from './utils'
@@ -19,7 +19,7 @@ import { pkgJson } from '../const'
  * @param {Args} args - The arguments object containing the headers and their values.
  * @return {string} The generated POT header.
  */
-export function generateHeader(args: Args): Record<string, string> {
+export function generateHeader(args: Args): Record<PotHeaders, string> {
 	/** @type {Record<string, string>} */
 	const headerData = {
 		...args.headers,
@@ -40,22 +40,24 @@ export function generateHeader(args: Args): Record<string, string> {
 				'AUTHOR EMAIL',
 		},
 	} as const
+	const authorString = `${headerData.author} <${headerData.email}>`
+	const domain = headerData.domain ? `X-Domain: ${headerData.domain}` : ''
 
 	return {
 		'Project-Id-Version': `${headerData.slug} ${headerData.version}`,
-		'Report-Msgid-Bugs-To': `${headerData.bugs.email} ${headerData.bugs.url}`,
+		'Report-Msgid-Bugs-To': authorString,
 		'MIME-Version': `1.0`,
 		'Content-Transfer-Encoding': `8bit`,
 		'content-type': 'text/plain; charset=iso-8859-1',
 		'plural-forms': 'nplurals=2; plural=(n!=1);',
 		'POT-Creation-Date': `${new Date().toISOString()}`,
 		'PO-Revision-Date': `${new Date().getFullYear()}-MO-DA HO:MI+ZONE`,
-		'Last-Translator': `${headerData.author} <${headerData.email}>`,
-		'Language-Team': `${headerData.author} <${headerData.email}>`,
+		'Last-Translator': authorString,
+		'Language-Team': authorString,
 		'X-Generator': `${pkgJson.name} ${pkgJson.version}`,
 		Language: `${headerData.language}`,
 		// add domain if specified
-		'X-Domain': headerData.domain ? `${headerData.domain}` : '',
+		domain,
 	}
 }
 

--- a/src/parser/makePot.ts
+++ b/src/parser/makePot.ts
@@ -22,13 +22,7 @@ export async function makePot(args: Args): Promise<string> {
 	args.headers = {
 		...args.headers,
 		...pkgData,
-		...{
-			name: metadata.name,
-			url: metadata.url,
-			description: metadata.description,
-			author: metadata.author,
-			authorUri: metadata.authorUri,
-		},
+		...metadata,
 	} as Args['headers']
 
 	/** generate the pot file */


### PR DESCRIPTION
this PR fix the issue around the missing data, but still some enhancements could be done 

- some package json data like "bug" can be both string or object but currently only the string version is captured
- the email author is optional for the pot file header but is missing in the WordPress plugin or header 
- also composer.json can provide some info but currently isn't parsed at all

close #8 