### PR TITLE
Code cleanup

### DIFF
--- a/src/extractors/headers.ts
+++ b/src/extractors/headers.ts
@@ -176,8 +176,6 @@ function consolidateUserHeaderData(args: Args): I18nHeaders {
 	const email = pkgAuthor?.email;
 	// this is the author with email address in this format: author <email>
 	const authorString = `${author} <${email}>`;
-	// if textDomain is provided, add it to the header
-	const xDomain = textDomain ? `X-Domain: ${textDomain}` : "";
 	// get the current directory name as slug
 	const currentDir = process
 		.cwd()
@@ -186,23 +184,23 @@ function consolidateUserHeaderData(args: Args): I18nHeaders {
 		?.toLowerCase()
 		.replace(" ", "-");
 	const slug =
-		currentDir || args.slug || args.domain === "theme"
-			? "THEME NAME"
-			: "PLUGIN NAME";
+		args.slug ||
+		currentDir ||
+		(args.domain === "theme" ? "THEME NAME" : "PLUGIN NAME");
 
 	return {
 		...args.headers,
 		author: authorName,
 		authorString: authorString, // this is the author with email address in this format: author <email>
-		slug: args.slug || "PLUGIN NAME",
+		slug,
 		email,
 		bugs,
 		license: args.headers?.license || "gpl-2.0 or later",
-		version: args.headers?.version || pkgJsonData?.version || "1.0.0",
+		version: args.headers?.version || pkgJsonData.version || "0.0.1",
 		language: "en",
 		domain:
 			args.headers?.textDomain || args.headers?.slug || "PLUGIN TEXTDOMAIN",
-		xDomain,
+		xDomain: textDomain,
 	};
 }
 

--- a/src/fs/glob.ts
+++ b/src/fs/glob.ts
@@ -33,7 +33,7 @@ export function getParser(
 		case "php":
 			return php.default;
 		default:
-			return ext!;
+			return null;
 	}
 }
 

--- a/src/parser/makeJson.ts
+++ b/src/parser/makeJson.ts
@@ -53,7 +53,16 @@ export class MakeJsonCommand {
 	 * @private
 	 */
 	private paths: object | undefined;
-	private sourceDir: string;
+	/**
+	 * The source directory.
+	 * @private
+	 */
+	private readonly sourceDir: string;
+
+	/**
+	 * The constructor.
+	 * @param args - The arguments to the command.
+	 */
 	public constructor(args: MakeJsonArgs) {
 		this.sourceDir = path.relative(args.paths.cwd, args.source ?? "");
 		if (!fs.existsSync(this.sourceDir)) {

--- a/src/parser/tree.ts
+++ b/src/parser/tree.ts
@@ -40,7 +40,11 @@ function collectComments(node: SyntaxNode): string | undefined {
 export function doTree(sourceCode: string, filepath: string): SetOfBlocks {
 	// set up the parser
 	const parser = new Parser();
-	parser.setLanguage(getParser(filepath));
+	const parserExt = getParser(filepath);
+	// if no parser is found return empty
+	if (!parserExt) return new SetOfBlocks([], filepath);
+	// set the parser language
+	parser.setLanguage(parserExt);
 
 	// parse the file
 	const tree = parser.parse(sourceCode);

--- a/src/types.ts
+++ b/src/types.ts
@@ -171,3 +171,19 @@ export interface JedData {
 		messages: Record<string, unknown>;
 	};
 }
+
+/**
+ * The header data of the current plugin / theme as returned by the `extractHeaders` command.
+ */
+export interface I18nHeaders {
+	authorString: string;
+	bugs: string;
+	license: string;
+	author?: string;
+	domain: string;
+	xDomain: string;
+	language: string;
+	version: string;
+	slug: string;
+	email: string | undefined;
+}


### PR DESCRIPTION
After the recent changes some code needs to be updated or fixed

- [fallback for getParser whenever the file has an unknown extension](https://github.com/wp-blocks/make-pot/commit/e2610589ad892f24d7fb568716c1146359ef5180)
- [getParser should return the parser data and not the file extension](https://github.com/wp-blocks/make-pot/commit/342995ab08e11157217c18023135fd3b2ae714c3)
- [fixed duplicate header title](https://github.com/wp-blocks/make-pot/commit/dc70692cad0405c42ea610cd051c6abe5ac15fd8)

Additionally types were rationalized and the code was refactored a bit to make it more readable