### PR TITLE
Fix blade support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 				"glob": "^11.0.2",
 				"tannin": "^1.2.0",
 				"tree-sitter": "^0.21.1",
-				"tree-sitter-javascript": "^0.21.4",
+				"tree-sitter-javascript": "^0.23.1",
 				"tree-sitter-php": "^0.23.12",
 				"tree-sitter-typescript": "^0.23.2",
 				"yargs": "^17.7.1"
@@ -3134,20 +3134,20 @@
 			}
 		},
 		"node_modules/tree-sitter-javascript": {
-			"version": "0.21.4",
-			"resolved": "https://registry.npmjs.org/tree-sitter-javascript/-/tree-sitter-javascript-0.21.4.tgz",
-			"integrity": "sha512-Lrk8yahebwrwc1sWJE9xPcz1OnnqiEV7Dh5fbN6EN3wNAdu9r06HpTqLqDwUUbnG4EB46Sfk+FJFAOldfoKLOw==",
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/tree-sitter-javascript/-/tree-sitter-javascript-0.23.1.tgz",
+			"integrity": "sha512-/bnhbrTD9frUYHQTiYnPcxyHORIw157ERBa6dqzaKxvR/x3PC4Yzd+D1pZIMS6zNg2v3a8BZ0oK7jHqsQo9fWA==",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
-				"node-addon-api": "^8.0.0",
-				"node-gyp-build": "^4.8.1"
+				"node-addon-api": "^8.2.2",
+				"node-gyp-build": "^4.8.2"
 			},
 			"peerDependencies": {
 				"tree-sitter": "^0.21.1"
 			},
 			"peerDependenciesMeta": {
-				"tree_sitter": {
+				"tree-sitter": {
 					"optional": true
 				}
 			}
@@ -3184,25 +3184,6 @@
 			},
 			"peerDependencies": {
 				"tree-sitter": "^0.21.0"
-			},
-			"peerDependenciesMeta": {
-				"tree-sitter": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/tree-sitter-typescript/node_modules/tree-sitter-javascript": {
-			"version": "0.23.1",
-			"resolved": "https://registry.npmjs.org/tree-sitter-javascript/-/tree-sitter-javascript-0.23.1.tgz",
-			"integrity": "sha512-/bnhbrTD9frUYHQTiYnPcxyHORIw157ERBa6dqzaKxvR/x3PC4Yzd+D1pZIMS6zNg2v3a8BZ0oK7jHqsQo9fWA==",
-			"hasInstallScript": true,
-			"license": "MIT",
-			"dependencies": {
-				"node-addon-api": "^8.2.2",
-				"node-gyp-build": "^4.8.2"
-			},
-			"peerDependencies": {
-				"tree-sitter": "^0.21.1"
 			},
 			"peerDependenciesMeta": {
 				"tree-sitter": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@wp-blocks/make-pot",
-			"version": "1.5.1",
+			"version": "1.6.0",
 			"hasInstallScript": true,
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
@@ -17,10 +17,10 @@
 				"gettext-parser": "^4.0.4",
 				"glob": "^11.0.2",
 				"tannin": "^1.2.0",
-				"tree-sitter": "^0.20.6",
-				"tree-sitter-javascript": "^0.20.4",
-				"tree-sitter-php": "^0.20.0",
-				"tree-sitter-typescript": "^0.20.5",
+				"tree-sitter": "^0.21.1",
+				"tree-sitter-javascript": "^0.21.4",
+				"tree-sitter-php": "^0.23.12",
+				"tree-sitter-typescript": "^0.23.2",
 				"yargs": "^17.7.1"
 			},
 			"bin": {
@@ -2310,35 +2310,6 @@
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
 		},
-		"node_modules/base64-js": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			]
-		},
-		"node_modules/bl": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-			"integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-			"dependencies": {
-				"buffer": "^5.5.0",
-				"inherits": "^2.0.4",
-				"readable-stream": "^3.4.0"
-			}
-		},
 		"node_modules/brace-expansion": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -2378,29 +2349,6 @@
 				"node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
 			}
 		},
-		"node_modules/buffer": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.1.13"
-			}
-		},
 		"node_modules/caniuse-lite": {
 			"version": "1.0.30001718",
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001718.tgz",
@@ -2419,11 +2367,6 @@
 					"url": "https://github.com/sponsors/ai"
 				}
 			]
-		},
-		"node_modules/chownr": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
 		},
 		"node_modules/cli-progress": {
 			"version": "3.12.0",
@@ -2547,36 +2490,6 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/decompress-response": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-			"integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-			"dependencies": {
-				"mimic-response": "^3.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/deep-extend": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-			"engines": {
-				"node": ">=4.0.0"
-			}
-		},
-		"node_modules/detect-libc": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
-			"integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/eastasianwidth": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -2598,14 +2511,6 @@
 			"integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
 			"dependencies": {
 				"iconv-lite": "^0.6.2"
-			}
-		},
-		"node_modules/end-of-stream": {
-			"version": "1.4.4",
-			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-			"dependencies": {
-				"once": "^1.4.0"
 			}
 		},
 		"node_modules/esbuild": {
@@ -2664,14 +2569,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/expand-template": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-			"integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/foreground-child": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
@@ -2686,11 +2583,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
 			}
-		},
-		"node_modules/fs-constants": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
 		},
 		"node_modules/function-bind": {
 			"version": "1.1.2",
@@ -2757,11 +2649,6 @@
 				}
 			]
 		},
-		"node_modules/github-from-package": {
-			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-			"integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="
-		},
 		"node_modules/glob": {
 			"version": "11.0.2",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-11.0.2.tgz",
@@ -2806,34 +2693,10 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/ieee754": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			]
-		},
 		"node_modules/inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-		},
-		"node_modules/ini": {
-			"version": "1.3.8",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
 		},
 		"node_modules/is-core-module": {
 			"version": "2.16.1",
@@ -2889,17 +2752,6 @@
 				"node": "20 || >=22"
 			}
 		},
-		"node_modules/mimic-response": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-			"integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/minimatch": {
 			"version": "10.0.1",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
@@ -2914,14 +2766,6 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/minimist": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/minipass": {
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
@@ -2930,44 +2774,30 @@
 				"node": ">=16 || 14 >=14.17"
 			}
 		},
-		"node_modules/mkdirp-classic": {
-			"version": "0.5.3",
-			"resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-			"integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
-		},
-		"node_modules/nan": {
-			"version": "2.22.2",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.22.2.tgz",
-			"integrity": "sha512-DANghxFkS1plDdRsX0X9pm0Z6SJNN6gBdtXfanwoZ8hooC5gosGFSBGRYHUVPz1asKA/kMRqDRdHrluZ61SpBQ=="
-		},
-		"node_modules/napi-build-utils": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
-			"integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="
-		},
-		"node_modules/node-abi": {
-			"version": "3.75.0",
-			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.75.0.tgz",
-			"integrity": "sha512-OhYaY5sDsIka7H7AtijtI9jwGYLyl29eQn/W623DiN/MIv5sUqc4g7BIDThX+gb7di9f6xK02nkp8sdfFWZLTg==",
-			"dependencies": {
-				"semver": "^7.3.5"
-			},
+		"node_modules/node-addon-api": {
+			"version": "8.4.0",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.4.0.tgz",
+			"integrity": "sha512-D9DI/gXHvVmjHS08SVch0Em8G5S1P+QWtU31appcKT/8wFSPRcdHadIFSAntdMMVM5zz+/DL+bL/gz3UDppqtg==",
+			"license": "MIT",
 			"engines": {
-				"node": ">=10"
+				"node": "^18 || ^20 || >= 21"
+			}
+		},
+		"node_modules/node-gyp-build": {
+			"version": "4.8.4",
+			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+			"integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+			"license": "MIT",
+			"bin": {
+				"node-gyp-build": "bin.js",
+				"node-gyp-build-optional": "optional.js",
+				"node-gyp-build-test": "build-test.js"
 			}
 		},
 		"node_modules/node-releases": {
 			"version": "2.0.19",
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
 			"integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw=="
-		},
-		"node_modules/once": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-			"dependencies": {
-				"wrappy": "1"
-			}
 		},
 		"node_modules/package-json-from-dist": {
 			"version": "1.0.0",
@@ -3006,54 +2836,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
 			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
-		},
-		"node_modules/prebuild-install": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
-			"integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
-			"dependencies": {
-				"detect-libc": "^2.0.0",
-				"expand-template": "^2.0.3",
-				"github-from-package": "0.0.0",
-				"minimist": "^1.2.3",
-				"mkdirp-classic": "^0.5.3",
-				"napi-build-utils": "^2.0.0",
-				"node-abi": "^3.3.0",
-				"pump": "^3.0.0",
-				"rc": "^1.2.7",
-				"simple-get": "^4.0.0",
-				"tar-fs": "^2.0.0",
-				"tunnel-agent": "^0.6.0"
-			},
-			"bin": {
-				"prebuild-install": "bin.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/pump": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
-			"integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
-			"dependencies": {
-				"end-of-stream": "^1.1.0",
-				"once": "^1.3.1"
-			}
-		},
-		"node_modules/rc": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-			"dependencies": {
-				"deep-extend": "^0.6.0",
-				"ini": "~1.3.0",
-				"minimist": "^1.2.0",
-				"strip-json-comments": "~2.0.1"
-			},
-			"bin": {
-				"rc": "cli.js"
-			}
 		},
 		"node_modules/readable-stream": {
 			"version": "3.6.2",
@@ -3157,23 +2939,13 @@
 		"node_modules/safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true
 		},
 		"node_modules/safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-		},
-		"node_modules/semver": {
-			"version": "7.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-			"integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
 		},
 		"node_modules/shebang-command": {
 			"version": "2.0.0",
@@ -3203,49 +2975,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/simple-concat": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-			"integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			]
-		},
-		"node_modules/simple-get": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-			"integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"decompress-response": "^6.0.0",
-				"once": "^1.3.1",
-				"simple-concat": "^1.0.0"
 			}
 		},
 		"node_modules/string_decoder": {
@@ -3374,14 +3103,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/strip-json-comments": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-			"integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/supports-preserve-symlinks-flag": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -3401,79 +3122,92 @@
 				"@tannin/plural-forms": "^1.1.0"
 			}
 		},
-		"node_modules/tar-fs": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.2.tgz",
-			"integrity": "sha512-EsaAXwxmx8UB7FRKqeozqEPop69DXcmYwTQwXvyAPF352HJsPdkVhvTaDPYqfNgruveJIJy3TA2l+2zj8LJIJA==",
-			"dependencies": {
-				"chownr": "^1.1.1",
-				"mkdirp-classic": "^0.5.2",
-				"pump": "^3.0.0",
-				"tar-stream": "^2.1.4"
-			}
-		},
-		"node_modules/tar-stream": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-			"integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-			"dependencies": {
-				"bl": "^4.0.3",
-				"end-of-stream": "^1.4.1",
-				"fs-constants": "^1.0.0",
-				"inherits": "^2.0.3",
-				"readable-stream": "^3.1.1"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/tree-sitter": {
-			"version": "0.20.6",
-			"resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.20.6.tgz",
-			"integrity": "sha512-GxJodajVpfgb3UREzzIbtA1hyRnTxVbWVXrbC6sk4xTMH5ERMBJk9HJNq4c8jOJeUaIOmLcwg+t6mez/PDvGqg==",
+			"version": "0.21.1",
+			"resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.21.1.tgz",
+			"integrity": "sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ==",
 			"hasInstallScript": true,
+			"license": "MIT",
 			"dependencies": {
-				"nan": "^2.18.0",
-				"prebuild-install": "^7.1.1"
+				"node-addon-api": "^8.0.0",
+				"node-gyp-build": "^4.8.0"
 			}
 		},
 		"node_modules/tree-sitter-javascript": {
-			"version": "0.20.4",
-			"resolved": "https://registry.npmjs.org/tree-sitter-javascript/-/tree-sitter-javascript-0.20.4.tgz",
-			"integrity": "sha512-7IUgGkZQROI7MmX2ErKhE3YP4+rM2qwBy5JeukE7fJQMEYP9nHpxvuQpa+eOX+hE1im2pWVc1yDCfVKKCBtxww==",
+			"version": "0.21.4",
+			"resolved": "https://registry.npmjs.org/tree-sitter-javascript/-/tree-sitter-javascript-0.21.4.tgz",
+			"integrity": "sha512-Lrk8yahebwrwc1sWJE9xPcz1OnnqiEV7Dh5fbN6EN3wNAdu9r06HpTqLqDwUUbnG4EB46Sfk+FJFAOldfoKLOw==",
 			"hasInstallScript": true,
+			"license": "MIT",
 			"dependencies": {
-				"nan": "^2.18.0"
+				"node-addon-api": "^8.0.0",
+				"node-gyp-build": "^4.8.1"
+			},
+			"peerDependencies": {
+				"tree-sitter": "^0.21.1"
+			},
+			"peerDependenciesMeta": {
+				"tree_sitter": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/tree-sitter-php": {
-			"version": "0.20.0",
-			"resolved": "https://registry.npmjs.org/tree-sitter-php/-/tree-sitter-php-0.20.0.tgz",
-			"integrity": "sha512-di7d1jjAu05Hj9AufXlUQzTHGaThemU2HV9MjE17HnbW8TfuwNzH0Q0BQuJLrIJipjK9bhqhNe1fS9wtkyUkYg==",
+			"version": "0.23.12",
+			"resolved": "https://registry.npmjs.org/tree-sitter-php/-/tree-sitter-php-0.23.12.tgz",
+			"integrity": "sha512-VwkBVOahhC2NYXK/Fuqq30NxuL/6c2hmbxEF4jrB7AyR5rLc7nT27mzF3qoi+pqx9Gy2AbXnGezF7h4MeM6YRA==",
 			"hasInstallScript": true,
+			"license": "MIT",
 			"dependencies": {
-				"nan": "^2.18.0"
+				"node-addon-api": "^8.2.2",
+				"node-gyp-build": "^4.8.2"
+			},
+			"peerDependencies": {
+				"tree-sitter": "^0.21.1"
+			},
+			"peerDependenciesMeta": {
+				"tree-sitter": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/tree-sitter-typescript": {
-			"version": "0.20.5",
-			"resolved": "https://registry.npmjs.org/tree-sitter-typescript/-/tree-sitter-typescript-0.20.5.tgz",
-			"integrity": "sha512-RzK/Pc6k4GiXvInIBlo8ZggekP6rODfW2P6KHFCTSUHENsw6ynh+iacFhfkJRa4MT8EIN2WHygFJ7076/+eHKg==",
+			"version": "0.23.2",
+			"resolved": "https://registry.npmjs.org/tree-sitter-typescript/-/tree-sitter-typescript-0.23.2.tgz",
+			"integrity": "sha512-e04JUUKxTT53/x3Uq1zIL45DoYKVfHH4CZqwgZhPg5qYROl5nQjV+85ruFzFGZxu+QeFVbRTPDRnqL9UbU4VeA==",
 			"hasInstallScript": true,
+			"license": "MIT",
 			"dependencies": {
-				"nan": "^2.18.0",
-				"tree-sitter": "^0.20.6"
+				"node-addon-api": "^8.2.2",
+				"node-gyp-build": "^4.8.2",
+				"tree-sitter-javascript": "^0.23.1"
+			},
+			"peerDependencies": {
+				"tree-sitter": "^0.21.0"
+			},
+			"peerDependenciesMeta": {
+				"tree-sitter": {
+					"optional": true
+				}
 			}
 		},
-		"node_modules/tunnel-agent": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-			"integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+		"node_modules/tree-sitter-typescript/node_modules/tree-sitter-javascript": {
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/tree-sitter-javascript/-/tree-sitter-javascript-0.23.1.tgz",
+			"integrity": "sha512-/bnhbrTD9frUYHQTiYnPcxyHORIw157ERBa6dqzaKxvR/x3PC4Yzd+D1pZIMS6zNg2v3a8BZ0oK7jHqsQo9fWA==",
+			"hasInstallScript": true,
+			"license": "MIT",
 			"dependencies": {
-				"safe-buffer": "^5.0.1"
+				"node-addon-api": "^8.2.2",
+				"node-gyp-build": "^4.8.2"
 			},
-			"engines": {
-				"node": "*"
+			"peerDependencies": {
+				"tree-sitter": "^0.21.1"
+			},
+			"peerDependenciesMeta": {
+				"tree-sitter": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/typescript": {
@@ -3665,11 +3399,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"node_modules/wrappy": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
 		},
 		"node_modules/y18n": {
 			"version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 	],
 	"scripts": {
 		"postinstall": "npm rebuild tree-sitter tree-sitter-typescript tree-sitter-php tree-sitter-javascript --force",
-		"build": "npx esbuild ./src/**/* --format=cjs --minify --outdir=lib --platform=node",
+		"build": "npx esbuild ./src/**/* ./src/*.ts --format=cjs --minify --outdir=lib --platform=node",
 		"watch": "tsc --watch",
 		"lint": "npx @biomejs/biome check --write src",
 		"rm": "rmdir /s /q lib",
@@ -67,7 +67,7 @@
 		"glob": "^11.0.2",
 		"tannin": "^1.2.0",
 		"tree-sitter": "^0.21.1",
-		"tree-sitter-javascript": "^0.21.4",
+		"tree-sitter-javascript": "^0.23.1",
 		"tree-sitter-php": "^0.23.12",
 		"tree-sitter-typescript": "^0.23.2",
 		"yargs": "^17.7.1"

--- a/package.json
+++ b/package.json
@@ -66,10 +66,10 @@
 		"gettext-parser": "^4.0.4",
 		"glob": "^11.0.2",
 		"tannin": "^1.2.0",
-		"tree-sitter": "^0.20.6",
-		"tree-sitter-javascript": "^0.20.4",
-		"tree-sitter-php": "^0.20.0",
-		"tree-sitter-typescript": "^0.20.5",
+		"tree-sitter": "^0.21.1",
+		"tree-sitter-javascript": "^0.21.4",
+		"tree-sitter-php": "^0.23.12",
+		"tree-sitter-typescript": "^0.23.2",
 		"yargs": "^17.7.1"
 	},
 	"devDependencies": {

--- a/src/fs/glob.ts
+++ b/src/fs/glob.ts
@@ -31,7 +31,7 @@ export function getParser(
 		case "cjs":
 			return Javascript.default;
 		case "php":
-			return php.default;
+			return php.php;
 		default:
 			return null;
 	}

--- a/src/fs/glob.ts
+++ b/src/fs/glob.ts
@@ -8,7 +8,7 @@ import * as php from "tree-sitter-php";
 // @ts-ignore
 import * as ts from "tree-sitter-typescript";
 import type { Args, Patterns } from "../types.js";
-import { detectPatternType } from "../utils/common.js";
+import { detectPatternType, getFileExtension } from "../utils/common.js";
 
 /**
  * Return the parser based on the file extension
@@ -19,7 +19,7 @@ import { detectPatternType } from "../utils/common.js";
 export function getParser(
 	file: string,
 ): string | { name: string; language: unknown } | null {
-	const ext = file.split(".").pop();
+	const ext = getFileExtension(file);
 	switch (ext) {
 		case "ts":
 			return ts.typescript;

--- a/src/fs/glob.ts
+++ b/src/fs/glob.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 import { Glob, type Path } from "glob";
 import { minimatch } from "minimatch";
 // @ts-ignore
-import * as Javascript from "tree-sitter-javascript";
+import * as javascript from "tree-sitter-javascript";
 // @ts-ignore
 import * as php from "tree-sitter-php";
 // @ts-ignore
@@ -29,7 +29,7 @@ export function getParser(
 		case "jsx":
 		case "mjs":
 		case "cjs":
-			return Javascript.default;
+			return javascript;
 		case "php":
 			return php.php;
 		case "blade.php":

--- a/src/fs/glob.ts
+++ b/src/fs/glob.ts
@@ -32,6 +32,8 @@ export function getParser(
 			return Javascript.default;
 		case "php":
 			return php.php;
+		case "blade.php":
+			return php.php_only;
 		default:
 			return null;
 	}

--- a/src/parser/patterns.ts
+++ b/src/parser/patterns.ts
@@ -18,7 +18,7 @@ export function getPatterns(args: Args) {
 	if (args.options) {
 		// js typescript mjs cjs etc
 		if (args.options.skip.blade) {
-			pattern.exclude.push("**/blade.php");
+			pattern.exclude.push("**/*.blade.php");
 		} else if (args.options.skip.php) {
 			pattern.exclude.push("**/*.php", "**/*.blade.php");
 		}

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -78,6 +78,18 @@ export function detectPatternType(
 }
 
 /**
+ * Gets the file extension from a filename.
+ * @param filename - The name of the file to extract the extension from.
+ * @returns The file extension, or 'blade.php' for Blade templates.
+ */
+export function getFileExtension(filename: string): string {
+	if (filename.endsWith(".blade.php")) {
+		return "blade.php";
+	}
+	return filename.split(".").pop() || "";
+}
+
+/**
  * Generates a copyright comment for the specified slug and license.
  *
  * @param slug - The slug to include in the copyright comment

--- a/tests/extract.test.js
+++ b/tests/extract.test.js
@@ -58,6 +58,44 @@ describe("getStrings", () => {
 		assert.deepStrictEqual(result.blocks[0].toJson(), expected.toJson());
 	});
 
+	it("should extract translations from blade", () => {
+		const content = `<h1>{{ __('Hello World', 'greeting') }}</h1>`;
+
+		const filename = "filename.blade.php";
+
+		const result = doTree(content, filename);
+
+		const expected = new Block([]);
+		expected.msgid = "Hello World";
+		expected.msgstr = [""];
+		expected.comments = {
+			reference: ["filename.blade.php:1"],
+			translator: [""],
+		};
+
+		assert.deepStrictEqual(result.blocks[0].toJson(), expected.toJson());
+	});
+
+	it("should extract translations from blade @php block", () => {
+		const content = `@php
+			$greeting = __('Hello World', 'greeting');
+		@endphp`;
+
+		const filename = "filename.blade.php";
+
+		const result = doTree(content, filename);
+
+		const expected = new Block([]);
+		expected.msgid = "Hello World";
+		expected.msgstr = [""];
+		expected.comments = {
+			reference: ["filename.blade.php:2"],
+			translator: [""],
+		};
+
+		assert.deepStrictEqual(result.blocks[0].toJson(), expected.toJson());
+	});
+
 	it("should extract translations with context", () => {
 		const content = `<?php __('Hello World', 'greeting'); ?>`;
 		const filename = "filename.php";


### PR DESCRIPTION
This PR fixes support for blade templates, as reported in #70.

**The problem:**
Blade templates are parsed with `tree-sitter-php`. The parser requires code to be within opening and closing `<?php`, `?>` tags. Blade doesn't use these, so the parser was not able to extract strings from blade files.

**The solution:**
Use `tree-sitter-php` in the `php_only` parser mode, which parses top-level statements without opening and closing tags. This mode is not available in the version of `tree-sitter-php` that was previously used, so it needed to be updated.

Summary of changes:
- Updated `tree-sitter` depencencies. I had to update all of them to resolve peer-dependency issues that arose from updating only `tree-sitter-php`.
- Added tests for blade templates using both `{{}}` echo statements and `@php` directives.
- Added utility function to get file extensions, that takes "blade.php" into account.
- Corrected the glob pattern for excluding blade files when the `--skip-blade` setting is used.

Tell me if you have any comments or questions!

close #70