### PR TITLE
Handles errors thrown during file parse

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@wp-blocks/make-pot",
-	"version": "1.6.1",
+	"version": "1.6.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@wp-blocks/make-pot",
-			"version": "1.6.1",
+			"version": "1.6.2",
 			"hasInstallScript": true,
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
@@ -1513,9 +1513,9 @@
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
 		},
 		"node_modules/@babel/types": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.1.tgz",
-			"integrity": "sha512-+EzkxvLNfiUeKMgy/3luqfsCWFRXLb7U6wNQTk60tovuckwB15B191tJWvpp4HjiQWdJkCxO3Wbvc6jlk3Xb2Q==",
+			"version": "7.28.1",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.1.tgz",
+			"integrity": "sha512-x0LvFTekgSX+83TI28Y9wYPUfzrnl2aT5+5QLnO6v7mSJYtEEevuDRN0F0uSHRk1G1IWZC43o00Y0xDDrpBGPQ==",
 			"dependencies": {
 				"@babel/helper-string-parser": "^7.27.1",
 				"@babel/helper-validator-identifier": "^7.27.1"
@@ -3157,7 +3157,6 @@
 			"resolved": "https://registry.npmjs.org/tree-sitter-php/-/tree-sitter-php-0.23.12.tgz",
 			"integrity": "sha512-VwkBVOahhC2NYXK/Fuqq30NxuL/6c2hmbxEF4jrB7AyR5rLc7nT27mzF3qoi+pqx9Gy2AbXnGezF7h4MeM6YRA==",
 			"hasInstallScript": true,
-			"license": "MIT",
 			"dependencies": {
 				"node-addon-api": "^8.2.2",
 				"node-gyp-build": "^4.8.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wp-blocks/make-pot",
-	"version": "1.6.1",
+	"version": "1.6.2",
 	"license": "GPL-3.0-or-later",
 	"homepage": "https://wp-blocks.github.io/make-pot/",
 	"description": "A Node.js script for generating a POT file from source code",

--- a/src/fs/fs.ts
+++ b/src/fs/fs.ts
@@ -66,15 +66,6 @@ export function getEncodingCharset(charset: string | undefined): string {
 
 /**
  * The output path for the pot file.
- * @param outpath - the output path for the pot/json files
- * @return {string} - the output path
- */
-export function getOutputPath(outpath?: string): string {
-	return path.join(process.cwd(), outpath ?? "languages");
-}
-
-/**
- * The output path for the pot file.
  * @param args - the command line arguments
  */
 function getOutputFilePath(args: Args): string {

--- a/src/parser/makeJson.ts
+++ b/src/parser/makeJson.ts
@@ -198,6 +198,10 @@ export class MakeJsonCommand {
 			// get the strings used in the script
 			const scriptContent = this.parseScript(script);
 
+			if (!scriptContent) {
+				return null;
+			}
+
 			// compare the strings used in the script with the strings in the po file
 			const stringsNotInPoFile = this.compareStrings(
 				scriptContent.blocks,
@@ -256,7 +260,7 @@ export class MakeJsonCommand {
 		};
 
 		// Domain name to use for the Jed format
-		const domain = "messages";
+		const domain: string = "messages";
 
 		const generator = `${packageJson.name}/${packageJson.version}`;
 
@@ -264,7 +268,7 @@ export class MakeJsonCommand {
 		const jedData: JedData = {
 			[domain]: {
 				"": {
-					domain: domain,
+					domain,
 					lang: languageIsoCode || header.Language || "en",
 					plural_forms:
 						header["Plural-Forms"] || "nplurals=2; plural=(n != 1);",
@@ -417,7 +421,7 @@ export class MakeJsonCommand {
 		return filteredPo;
 	}
 
-	private parseScript(script: string): SetOfBlocks {
+	private parseScript(script: string): SetOfBlocks | undefined {
 		const fileContent = fs.readFileSync(path.join(this.source, script), "utf8");
 		const transformedScript = transformSync(fileContent, {
 			configFile: false,

--- a/src/parser/process.ts
+++ b/src/parser/process.ts
@@ -47,11 +47,12 @@ export async function processFiles(
 				),
 			);
 		} else if (allowedFormats.includes(ext)) {
-			tasks.push(
-				readFileAsync(fileRealPath).then((content) =>
-					doTree(content, file, args.debug),
-				),
+			const fileTree = readFileAsync(fileRealPath).then((content) =>
+				doTree(content, file, args.debug),
 			);
+			if (fileTree) {
+				tasks.push(fileTree as Promise<SetOfBlocks>);
+			}
 		}
 
 		if (progressBar) {

--- a/src/parser/tree.ts
+++ b/src/parser/tree.ts
@@ -182,10 +182,21 @@ export function doTree(
 		}
 	}
 
-	// parse the file
 	try {
 		if (sourceCode) {
-			const tree = parser.parse(sourceCode);
+			const fileSize = Buffer.byteLength(sourceCode, "utf8");
+			let bufferSize = 1024 * 32; // 32 KB default buffer size
+
+			if (fileSize >= bufferSize) {
+				bufferSize = fileSize + 32; // dynamic buffer size with 32 bytes of padding
+			}
+
+			if (fileSize >= 1024 * 1024 * 2) {
+				console.warn(`File size warning: ${filepath} exceeds 2 MB.`);
+			}
+
+			// parse the file
+			const tree = parser.parse(sourceCode, undefined, { bufferSize });
 			if (tree) {
 				traverse(tree.rootNode);
 			}

--- a/src/parser/tree.ts
+++ b/src/parser/tree.ts
@@ -51,9 +51,6 @@ export function doTree(
 	// set the parser language
 	parser.setLanguage(parserExt);
 
-	// parse the file
-	const tree = parser.parse(sourceCode);
-
 	// set up the translation object
 	const gettextTranslations: SetOfBlocks = new SetOfBlocks([], filepath);
 
@@ -165,7 +162,6 @@ export function doTree(
 				translationKeyIndex += 1;
 			}
 
-			// TODO: Alert about wrong translation domain?
 			const comments = collectComments(argsNode);
 
 			// Get the translation data
@@ -186,7 +182,17 @@ export function doTree(
 		}
 	}
 
-	traverse(tree.rootNode);
+	// parse the file
+	try {
+		if (sourceCode) {
+			const tree = parser.parse(sourceCode);
+			if (tree) {
+				traverse(tree.rootNode);
+			}
+		}
+	} catch (e) {
+		console.error(`Failed to parse ${filepath}: ${e}`);
+	}
 
 	// Return both matches and entries
 	return gettextTranslations;

--- a/src/types.ts
+++ b/src/types.ts
@@ -163,14 +163,22 @@ export interface TranslationStrings {
 	[msgctxt: string]: { [msgId: string]: GetTextTranslation };
 }
 
+/** The header of the JED file. */
+export interface JedHeader {
+	domain: string;
+	lang: string;
+	plural_forms: string;
+	[key: string]: string;
+}
+
 /**
  * The JSON data returned by the `makeJson` command.
  * @param {string} domain
- * @param {Record<string, unknown>} locale_data
+ * @param {Record<string, string | string[] | JedHeader>} locale_data
  */
 export interface JedData {
 	[domain: string]: {
-		[key: string]: string | string[];
+		[key: string]: string | string[] | JedHeader;
 	};
 }
 

--- a/tests/tree.test.js
+++ b/tests/tree.test.js
@@ -156,3 +156,24 @@ describe("doTree php test file", async () => {
 		assert.strictEqual(r.filter((block) => block.comments).length, 11);
 	});
 });
+
+describe("doTree large file", () => {
+	const filepath = "tests/fixtures/php.php";
+	const filePath = path.join(process.cwd(), filepath);
+	const fileContent = fs.readFileSync(filePath, "utf8");
+	it("should parse and extract strings from large files", () => {
+		let content = fileContent;
+
+		// Duplicate content to go over 32 kb
+		while (content.length < 1024 * 32) {
+			content += fileContent;
+		}
+
+		const filename = "filename.php";
+
+		const r = doTree(content, filename).blocks;
+
+		assert.strictEqual(r.map((block) => block).length, 19);
+		assert.strictEqual(r.filter((block) => block.comments).length, 19);
+	});
+});


### PR DESCRIPTION
I seems that with the current version of treesitter-php sometimes the file parsing fails. 

For that reason a try catch was introduced in order to avoid the script to fail

close #74 