### PR TITLE
Dynamic buffer size

### DIFF
--- a/src/parser/tree.ts
+++ b/src/parser/tree.ts
@@ -182,10 +182,17 @@ export function doTree(
 		}
 	}
 
-	// parse the file
 	try {
 		if (sourceCode) {
-			const tree = parser.parse(sourceCode);
+			const fileSize = Buffer.byteLength(sourceCode, "utf8");
+			let bufferSize = 1024 * 32; // 32 KB default buffer size
+
+			if (fileSize >= bufferSize) {
+				bufferSize = fileSize + 32; // dynamic buffer size with 32 bytes of padding
+			}
+
+			// parse the file
+			const tree = parser.parse(sourceCode, undefined, { bufferSize });
 			if (tree) {
 				traverse(tree.rootNode);
 			}

--- a/src/parser/tree.ts
+++ b/src/parser/tree.ts
@@ -191,6 +191,10 @@ export function doTree(
 				bufferSize = fileSize + 32; // dynamic buffer size with 32 bytes of padding
 			}
 
+			if (fileSize >= 1024 * 1024 * 2) {
+				console.warn(`File size warning: ${filepath} exceeds 2 MB.`);
+			}
+
 			// parse the file
 			const tree = parser.parse(sourceCode, undefined, { bufferSize });
 			if (tree) {

--- a/tests/tree.test.js
+++ b/tests/tree.test.js
@@ -156,3 +156,24 @@ describe("doTree php test file", async () => {
 		assert.strictEqual(r.filter((block) => block.comments).length, 11);
 	});
 });
+
+describe("doTree large file", () => {
+	const filepath = "tests/fixtures/php.php";
+	const filePath = path.join(process.cwd(), filepath);
+	const fileContent = fs.readFileSync(filePath, "utf8");
+	it("should extract translations and comments from large files", () => {
+		let content = fileContent;
+
+		// Duplicate content to go over 32 kb
+		while (content.length < 1024 * 32) {
+			content += fileContent;
+		}
+
+		const filename = "filename.php";
+
+		const r = doTree(content, filename).blocks;
+
+		assert.strictEqual(r.map((block) => block).length, 19);
+		assert.strictEqual(r.filter((block) => block.comments).length, 19);
+	});
+});

--- a/tests/tree.test.js
+++ b/tests/tree.test.js
@@ -161,7 +161,7 @@ describe("doTree large file", () => {
 	const filepath = "tests/fixtures/php.php";
 	const filePath = path.join(process.cwd(), filepath);
 	const fileContent = fs.readFileSync(filePath, "utf8");
-	it("should extract translations and comments from large files", () => {
+	it("should parse and extract strings from large files", () => {
 		let content = fileContent;
 
 		// Duplicate content to go over 32 kb


### PR DESCRIPTION
This PR implements dynamic sizing of the buffer used by `tree-sitter`, to fix #74 . The default 32 KB buffer size is maintained, but any files over that size will be parsed with a dynamic buffer size matching the file size + 32 bytes of padding instead.

I suggest that a warning is logged for files where the size starts to noticeably affect performance. It's currently set to 2 MB but I'm of course open to suggestions to change it. Logging for every file is over 32 kb might get noisy in some codebases.

Here are some performance metrics captured on my Macbook Pro M1:

| file size  | parse time |
| :-         | -: |
| 1 kb       | 10 ms |
| 100 kb     | 145 ms |
| 1 mb       | 1656 ms |
| 2 mb       | 3849 ms |
| 3 mb       | 6487 ms |
| 4 mb       | 11278 ms |
| 5 mb       | 13039 ms |
| 10 mb      | 40163 ms |
