### PR TITLE
Fix to parse `_n` and `_nx`, add command line option `--translation-domains` for filtering translations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ npx @wp-blocks/make-pot src languages --charset='utf-8' --include="src/**/*.{ts,
 - `--version`: Displays the version number of `make-pot`.
 - `-h`, `--help`: Displays help information.
 - `--slug <slug>`: Specifies the plugin or theme slug.
-- `--domain <domain>`: Specifies the text domain to look for in the source code.
+- `--domain <domain>`: Specifies the text domain to look for in the source code, you can choose "plugin", "theme", "block", "theme-block", "generic".
 - `--skip-js`: Skips JavaScript files during processing.
 - `--skip-php`: Skips PHP files during processing.
 - `--skip-blade`: Skips Blade files during processing.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ npx @wp-blocks/make-pot src languages --charset='utf-8' --include="src/**/*.{ts,
 - `--silent`: Suppresses output to stdout.
 - `--json`: Outputs the JSON gettext data.
 - `--charset`: Defines the encoding charset of the pot file, you can choose "iso-8859-1" and "uft-8" (defaults to iso-8859-1)
+- `--translation-domains`: Restrict to specific translation domains.
 - `--output`: Outputs the gettext data.
 
 ### Example usage

--- a/src/cli/getArgs.ts
+++ b/src/cli/getArgs.ts
@@ -29,7 +29,8 @@ export function getArgs(userArgs = {}): Args | MakeJsonArgs {
 				type: "string",
 			},
 			domain: {
-				describe: "Text domain to look for in the source code",
+				describe: "Text domain to look for in the source code. Valid domains are: plugin, theme, block, theme-block, generic.",
+				choices: ["plugin", "theme", "block", "theme-block", "generic"],
 				type: "string",
 			},
 			"skip-js": {

--- a/src/cli/getArgs.ts
+++ b/src/cli/getArgs.ts
@@ -117,6 +117,10 @@ export function getArgs(userArgs = {}): Args | MakeJsonArgs {
 				type: "string",
 				default: "latin1",
 			},
+			"translation-domains": {
+				describe: "Restrict to specific translation domains",
+				type: "array",
+			},
 			debug: {
 				describe: "Debug mode",
 				type: "boolean",

--- a/src/cli/parseCli.ts
+++ b/src/cli/parseCli.ts
@@ -132,6 +132,7 @@ export function parseCliArgs(
 				themeJson: !!args.skipThemeJson,
 				audit: !!args.skipAudit,
 			},
+			translationDomains: args.translationDomains ? Array.isArray(args.translationDomains) ? args.translationDomains.map(String) : [String(args.translationDomains)] : undefined,
 		},
 		// Patterns
 		patterns: {

--- a/src/parser/process.ts
+++ b/src/parser/process.ts
@@ -48,7 +48,7 @@ export async function processFiles(
 			);
 		} else if (allowedFormats.includes(ext)) {
 			const fileTree = readFileAsync(fileRealPath).then((content) =>
-				doTree(content, file, args.options?.translationDomains, args.debug),
+				doTree(content, file, args.debug, args),
 			);
 			if (fileTree) {
 				tasks.push(fileTree as Promise<SetOfBlocks>);

--- a/src/parser/process.ts
+++ b/src/parser/process.ts
@@ -48,7 +48,7 @@ export async function processFiles(
 			);
 		} else if (allowedFormats.includes(ext)) {
 			const fileTree = readFileAsync(fileRealPath).then((content) =>
-				doTree(content, file, args.debug),
+				doTree(content, file, args.options?.translationDomains, args.debug),
 			);
 			if (fileTree) {
 				tasks.push(fileTree as Promise<SetOfBlocks>);

--- a/src/parser/tree.ts
+++ b/src/parser/tree.ts
@@ -41,6 +41,7 @@ function collectComments(node: SyntaxNode): string | undefined {
 export function doTree(
 	sourceCode: string,
 	filepath: string,
+	translationDomains?: string[],
 	debugEnabled?: boolean,
 ): SetOfBlocks {
 	// set up the parser
@@ -113,6 +114,7 @@ export function doTree(
 				msgid: string;
 				msgid_plural: string;
 				msgstr: string;
+				text_domain: string;
 			}> = {};
 
 			const translationKeys =
@@ -160,6 +162,10 @@ export function doTree(
 
 				// increment the index of the translation key
 				translationKeyIndex += 1;
+			}
+
+			if (Array.isArray(translationDomains) && !translationDomains.includes(translation.text_domain as string)) {
+				return;
 			}
 
 			const comments = collectComments(argsNode);

--- a/src/parser/tree.ts
+++ b/src/parser/tree.ts
@@ -4,6 +4,7 @@ import { i18nFunctions } from "../const.js";
 import { Block, SetOfBlocks } from "gettext-merger";
 import { getParser } from "../fs/glob.js";
 import { reverseSlashes, stripTranslationMarkup } from "../utils/common.js";
+import { Args } from "../types.js";
 
 /**
  * Collect comments from the AST node and its preceding siblings.
@@ -36,13 +37,14 @@ function collectComments(node: SyntaxNode): string | undefined {
  * @param {string} sourceCode - The source code to be parsed.
  * @param {string} filepath - The path to the file being parsed.
  * @param {boolean} debugEnabled - Whether debug mode is enabled.
+ * @param {Args} args - The command line arguments, optional.
  * @return {SetOfBlocks} An array of translation strings.
  */
 export function doTree(
 	sourceCode: string,
 	filepath: string,
-	translationDomains?: string[],
 	debugEnabled?: boolean,
+	args?: Args,
 ): SetOfBlocks {
 	// set up the parser
 	const parser = new Parser();
@@ -169,7 +171,7 @@ export function doTree(
 				translationKeyIndex += 1;
 			}
 
-			if (Array.isArray(translationDomains) && !translationDomains.includes(translation.text_domain as string)) {
+			if (Array.isArray(args?.options?.translationDomains) && !args.options.translationDomains.includes(translation.text_domain as string)) {
 				return;
 			}
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -113,6 +113,7 @@ export interface Args {
 			themeJson?: boolean;
 			audit?: boolean;
 		};
+		translationDomains?: string[];
 	};
 	headers?: { [key in PotHeaders]: string };
 	patterns: Patterns;

--- a/tests/tree.test.js
+++ b/tests/tree.test.js
@@ -194,3 +194,22 @@ describe("doTree php filtered by translation domain", async () => {
 		assert.strictEqual(r.map((block) => block).length, 1);
 	});
 });
+
+describe("doTree php _n, _nx", async () => {
+	it("should extract translations and comments from code content", () => {
+		const content = `<?php
+
+      // translators: %d a number of years
+      _n( '%d year ago', '%d years go', 1, 'foo-plugin' );
+
+      // translators: %d a number of years
+      _nx( '%d year ago', '%d years go', 1, 'context', 'foo-plugin' );
+      `;
+
+		const filename = "filename.php";
+
+		const r = doTree(content, filename).blocks;
+
+		assert.strictEqual(r.filter((block) => block.msgctxt === 'context').length, 1);
+	});
+});

--- a/tests/tree.test.js
+++ b/tests/tree.test.js
@@ -177,3 +177,20 @@ describe("doTree large file", () => {
 		assert.strictEqual(r.filter((block) => block.comments).length, 19);
 	});
 });
+
+describe("doTree php filtered by translation domain", async () => {
+	it("should extract translations filtered by translation domain", () => {
+		const content = `<?php
+
+      __( 'hello, world' );
+      __( 'hello, foo', 'foo-plugin' );
+      __( 'hello, bar', 'bar-plugin' );
+      `;
+
+		const filename = "filename.php";
+
+		const r = doTree(content, filename, ['foo-plugin']).blocks;
+
+		assert.strictEqual(r.map((block) => block).length, 1);
+	});
+});

--- a/tests/tree.test.js
+++ b/tests/tree.test.js
@@ -189,9 +189,10 @@ describe("doTree php filtered by translation domain", async () => {
 
 		const filename = "filename.php";
 
-		const r = doTree(content, filename, ['foo-plugin']).blocks;
-
-		assert.strictEqual(r.map((block) => block).length, 1);
+		for (const translationDomain of ['default', 'foo-plugin', 'bar-plugin']) {
+			const r = doTree(content, filename, undefined, { options: { translationDomains: [translationDomain] } }).blocks;
+			assert.strictEqual(r.map((block) => block).length, 1);
+		}
 	});
 });
 


### PR DESCRIPTION
Fixed a bug in parsing `_n` and `_nx` where the argument order was handled incorrectly.
Also, if parsing fails, an error is output and no entry is generated. This is probably the correct behavior.

Added command line option `--translation-domains`.
This is useful when we want to use translations for our own domains in combination with translations for the `default` domain.